### PR TITLE
Fix: 뷰포트 밖에 요소가 있을 때 스크롤 오류 수정 #19

### DIFF
--- a/client/src/components/ModalView/index.tsx
+++ b/client/src/components/ModalView/index.tsx
@@ -21,11 +21,13 @@ export default function ModalView({
   );
 
   useEffect(() => {
-    document.body.style.overflow = 'hidden';
+    if (isMounted) {
+      document.body.style.overflow = 'hidden';
+    }
     return () => {
-      document.body.style.overflow = 'visible';
+      document.body.style.overflow = 'auto';
     };
-  }, []);
+  }, [isMounted]);
 
   if (!isMounted) return null;
 


### PR DESCRIPTION
![제목 없음](https://user-images.githubusercontent.com/37580351/180141614-e30a5498-7a4a-415b-aeba-2e096852fb5d.png)

모달이 렌더링될 때만, overflow: hidden이 적용되도록 변경함.

fix #19 