### PR TITLE
Add: 장바구니 아이템 개별 삭제, 수량 조절 기능 구현

### DIFF
--- a/client/src/components/CartList/CartItem.tsx
+++ b/client/src/components/CartList/CartItem.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { useAppSelector } from '@store/hooks';
+import { selectCartItem } from '@store/slices/cartSlice';
+import { GoodsOption } from '@typings/db';
+import CartItemImage from './CartItemImage';
+import CartItemInfo from './CartItemInfo';
+import { styles } from './styles';
+
+interface Props {
+  id: GoodsOption['id'];
+  size: GoodsOption['size'];
+}
+
+export default function CartItem({
+  id,
+  size,
+}: Props): React.ReactElement | null {
+  const item = useAppSelector(state => selectCartItem(state, id, size));
+
+  if (!item) return null;
+
+  return (
+    <li css={styles.cartItemZone}>
+      <CartItemImage img={item.img} alt={item.name} />
+      <CartItemInfo item={item} />
+    </li>
+  );
+}

--- a/client/src/components/CartList/CartItem.tsx
+++ b/client/src/components/CartList/CartItem.tsx
@@ -27,7 +27,7 @@ export default function CartItem({
 
   return (
     <li css={styles.cartItemZone}>
-      <CartItemImage img={item.img} alt={item.name} />
+      <CartItemImage id={item.id} img={item.img} alt={item.name} />
       <CartItemInfo item={item} />
       <button onClick={onClick}>
         <CgTrash size="2rem" />

--- a/client/src/components/CartList/CartItem.tsx
+++ b/client/src/components/CartList/CartItem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { useAppSelector } from '@store/hooks';
-import { selectCartItem } from '@store/slices/cartSlice';
+import { CgTrash } from 'react-icons/cg';
+import { useAppDispatch, useAppSelector } from '@store/hooks';
+import { removeCartItem, selectCartItem } from '@store/slices/cartSlice';
 import { GoodsOption } from '@typings/db';
 import CartItemImage from './CartItemImage';
 import CartItemInfo from './CartItemInfo';
@@ -17,12 +18,20 @@ export default function CartItem({
 }: Props): React.ReactElement | null {
   const item = useAppSelector(state => selectCartItem(state, id, size));
 
+  const appDispatch = useAppDispatch();
+  const onClick = () => {
+    appDispatch(removeCartItem({ id, size }));
+  };
+
   if (!item) return null;
 
   return (
     <li css={styles.cartItemZone}>
       <CartItemImage img={item.img} alt={item.name} />
       <CartItemInfo item={item} />
+      <button onClick={onClick}>
+        <CgTrash size="2rem" />
+      </button>
     </li>
   );
 }

--- a/client/src/components/CartList/CartItemImage.tsx
+++ b/client/src/components/CartList/CartItemImage.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { GoodsOption } from '@typings/db';
+import { styles } from './styles';
+
+interface Props {
+  img: GoodsOption['img'];
+  alt: GoodsOption['name'];
+}
+
+export default function CartItemImage({ img, alt }: Props): React.ReactElement {
+  return (
+    <span css={styles.cartItemImage}>
+      <img src={img} alt={alt} />
+    </span>
+  );
+}

--- a/client/src/components/CartList/CartItemImage.tsx
+++ b/client/src/components/CartList/CartItemImage.tsx
@@ -1,16 +1,22 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { GoodsOption } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
+  id: GoodsOption['id'];
   img: GoodsOption['img'];
   alt: GoodsOption['name'];
 }
 
-export default function CartItemImage({ img, alt }: Props): React.ReactElement {
+export default function CartItemImage({
+  id,
+  img,
+  alt,
+}: Props): React.ReactElement {
   return (
-    <span css={styles.cartItemImage}>
+    <Link to={`/goods/${id}`} css={styles.cartItemImage}>
       <img src={img} alt={alt} />
-    </span>
+    </Link>
   );
 }

--- a/client/src/components/CartList/CartItemInfo.tsx
+++ b/client/src/components/CartList/CartItemInfo.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { addThousandSeperatorToNumber } from '@lib/utils';
+import { GoodsOption } from '@typings/db';
+import { styles } from './styles';
+
+interface Props {
+  item: GoodsOption;
+}
+
+export default function CartItemInfo({ item }: Props): React.ReactElement {
+  return (
+    <span css={styles.cartItemInfo}>
+      <strong>{item.name}</strong>
+      <span>
+        Size: <strong>{item.size}</strong>
+      </span>
+      <strong>{addThousandSeperatorToNumber(item.price)}원</strong>
+    </span>
+  );
+}

--- a/client/src/components/CartList/CartItemInfo.tsx
+++ b/client/src/components/CartList/CartItemInfo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { addThousandSeperatorToNumber } from '@lib/utils';
 import { GoodsOption } from '@typings/db';
+import CartItemQuantityInput from './CartItemQuantityInput';
 import { styles } from './styles';
 
 interface Props {
@@ -15,6 +16,11 @@ export default function CartItemInfo({ item }: Props): React.ReactElement {
         Size: <strong>{item.size}</strong>
       </span>
       <strong>{addThousandSeperatorToNumber(item.price)}원</strong>
+      <CartItemQuantityInput
+        id={item.id}
+        size={item.size}
+        quantity={item.quantity}
+      />
     </span>
   );
 }

--- a/client/src/components/CartList/CartItemQuantityInput.tsx
+++ b/client/src/components/CartList/CartItemQuantityInput.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { useState } from 'react';
+import QuantityInput from '@components/QuantityInput';
+import { useAppDispatch } from '@store/hooks';
+import {
+  changeItemQuantity,
+  decrementItemQuantity,
+  incrementItemQuantity,
+} from '@store/slices/cartSlice';
+import { GoodsOption } from '@typings/db';
+
+interface Props {
+  id: GoodsOption['id'];
+  size: GoodsOption['size'];
+  quantity: GoodsOption['quantity'];
+}
+
+export default function CartItemQuantityInput({
+  id,
+  size,
+  quantity,
+}: Props): React.ReactElement {
+  const [value, setValue] = useState(quantity);
+  const appDispatch = useAppDispatch();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (Number.isNaN(value)) return;
+
+    setValue(value);
+  };
+
+  const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (e.target.value === '0') {
+      alert('최소 구매 수량은 1개입니다.');
+      setValue(quantity);
+      return;
+    }
+    if (quantity === value) return;
+    appDispatch(changeItemQuantity({ id, size, quantity: value }));
+  };
+
+  const onIncrement = () => {
+    if (value === 20) {
+      alert('최대 구매 가능 수량은 20개입니다.');
+      return;
+    }
+
+    setValue(prev => prev + 1);
+    appDispatch(incrementItemQuantity({ id, size }));
+  };
+
+  const onDecrement = () => {
+    if (value === 1) {
+      alert('최소 구매 수량은 1개입니다.');
+      return;
+    }
+
+    setValue(prev => prev - 1);
+    appDispatch(decrementItemQuantity({ id, size }));
+  };
+
+  return (
+    <QuantityInput
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      onIncrement={onIncrement}
+      onDecrement={onDecrement}
+    />
+  );
+}

--- a/client/src/components/CartList/index.tsx
+++ b/client/src/components/CartList/index.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { useAppSelector } from '@store/hooks';
+import { selectCart } from '@store/slices/cartSlice';
+import CartItem from './CartItem';
+import { styles } from './styles';
+
+export default function CartList(): React.ReactElement {
+  const cart = useAppSelector(selectCart);
+
+  return (
+    <section>
+      <ul css={styles.cartItemWrapper}>
+        {cart.map(cartItem => (
+          <CartItem
+            key={`${cartItem.id}+${cartItem.size}`}
+            id={cartItem.id}
+            size={cartItem.size}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/client/src/components/CartList/styles.tsx
+++ b/client/src/components/CartList/styles.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  cartItemWrapper: css({
+    margin: '20px 0',
+    borderTop: '1px solid #eee',
+  }),
+  cartItemZone: css({
+    display: 'flex',
+    borderBottom: '1px solid #eee',
+    padding: '10px 0',
+    fontSize: '1.3rem',
+    [mq('xs')]: {
+      fontSize: '1.4rem',
+    },
+  }),
+  cartItemImage: css({
+    flex: '0 0 auto',
+    width: 80,
+    height: 80,
+    [mq('xs')]: {
+      width: 100,
+      height: 100,
+    },
+  }),
+  cartItemInfo: css({
+    flex: '1 1 auto',
+    marginLeft: 15,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-evenly',
+    overflow: 'hidden',
+    '> *': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    strong: {
+      fontWeight: 700,
+    },
+  }),
+};

--- a/client/src/components/CartList/styles.tsx
+++ b/client/src/components/CartList/styles.tsx
@@ -32,6 +32,7 @@ export const styles = {
     justifyContent: 'space-evenly',
     overflow: 'hidden',
     '> *': {
+      padding: '4px 0',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',

--- a/client/src/components/GoodsItem/AddToCart.tsx
+++ b/client/src/components/GoodsItem/AddToCart.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
-import { useEffect } from 'react';
 import { useModalDispatch } from '@context/ModalContext';
 import { useOption } from '@context/OptionContext';
-import { useAppDispatch, useAppSelector } from '@store/hooks';
-import { addCartItem, selectCart } from '@store/slices/cartSlice';
+import { useAppDispatch } from '@store/hooks';
+import { addCartItem } from '@store/slices/cartSlice';
 import { styles } from './styles';
 
 export default function AddToCart(): React.ReactElement {
   const option = useOption();
-  const cart = useAppSelector(selectCart);
 
   const appDispatch = useAppDispatch();
   const modalDispatch = useModalDispatch();
@@ -17,10 +15,6 @@ export default function AddToCart(): React.ReactElement {
     appDispatch(addCartItem(option));
     modalDispatch({ type: 'OPEN_MODAL' });
   };
-
-  useEffect(() => {
-    localStorage.setItem('cart', JSON.stringify(cart));
-  }, [cart]);
 
   return (
     <button

--- a/client/src/layouts/App/AppLayout.tsx
+++ b/client/src/layouts/App/AppLayout.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
+import { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { Outlet } from 'react-router-dom';
 import LoaderProvider from '@context/LoaderContext';
 import Header from '@layouts/Header';
+import { useAppSelector } from '@store/hooks';
+import { selectCart } from '@store/slices/cartSlice';
 import { mq } from '@styles/mediaQueries';
 
 const styles = {
   containerInner: css({
+    fontSize: '1.5rem',
     [mq('lg')]: {
       width: 1100,
       margin: '0 auto',
@@ -15,6 +19,12 @@ const styles = {
 };
 
 export default function AppLayout(): React.ReactElement {
+  const cart = useAppSelector(selectCart);
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }, [cart]);
+
   return (
     <>
       <Header />

--- a/client/src/pages/Cart/index.tsx
+++ b/client/src/pages/Cart/index.tsx
@@ -1,5 +1,24 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import CartList from '@components/CartList';
+import { useAppSelector } from '@store/hooks';
+import { selectCart } from '@store/slices/cartSlice';
+import { styles } from './styles';
 
 export default function Cart(): React.ReactElement {
-  return <main></main>;
+  const cart = useAppSelector(selectCart);
+
+  return (
+    <main css={styles.cartZone}>
+      <h2 css={styles.cartTitle}>장바구니</h2>
+      {cart.length > 0 ? (
+        <CartList />
+      ) : (
+        <div css={styles.noneCart}>
+          <p>장바구니에 담긴 상품이 없습니다.</p>
+          <Link to="/">상품 구경하기</Link>
+        </div>
+      )}
+    </main>
+  );
 }

--- a/client/src/pages/Cart/styles.tsx
+++ b/client/src/pages/Cart/styles.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  cartZone: css({
+    padding: 20,
+    [mq('lg')]: {
+      padding: '20px 0',
+    },
+  }),
+  cartTitle: css({
+    fontSize: '2.2rem',
+    fontWeight: 700,
+    [mq('xs')]: {
+      fontSize: '2.4rem',
+    },
+  }),
+  noneCart: css({
+    padding: '150px 0',
+    margin: '20px 0',
+    backgroundColor: '#eee',
+    textAlign: 'center',
+    fontSize: '1.4rem',
+    a: {
+      display: 'inline-block',
+      marginTop: 20,
+      padding: 15,
+      borderRadius: 5,
+      backgroundColor: '#fff',
+      fontWeight: 700,
+      color: 'inherit',
+    },
+  }),
+};

--- a/client/src/store/slices/cartSlice.ts
+++ b/client/src/store/slices/cartSlice.ts
@@ -63,6 +63,12 @@ export const { addCartItem } = cartSlice.actions;
 
 export const selectCart = (state: RootState) => state.cart;
 
+export const selectCartItem = (
+  state: RootState,
+  id: GoodsOption['id'],
+  size: GoodsOption['size']
+) => state.cart.find(cartItem => cartItem.id === id && cartItem.size === size);
+
 export const selectCartItemCount = createSelector(
   selectCart,
   cart => cart.length

--- a/client/src/store/slices/cartSlice.ts
+++ b/client/src/store/slices/cartSlice.ts
@@ -54,12 +54,24 @@ const cartSlice = createSlice({
           return prev.concat(curr);
         }, []);
     },
+    removeCartItem: (
+      state,
+      action: PayloadAction<{
+        id: GoodsOption['id'];
+        size: GoodsOption['size'];
+      }>
+    ) => {
+      return state.filter(
+        item =>
+          !(item.id === action.payload.id && item.size === action.payload.size)
+      );
+    },
   },
 });
 
 export default cartSlice.reducer;
 
-export const { addCartItem } = cartSlice.actions;
+export const { addCartItem, removeCartItem } = cartSlice.actions;
 
 export const selectCart = (state: RootState) => state.cart;
 

--- a/client/src/store/slices/cartSlice.ts
+++ b/client/src/store/slices/cartSlice.ts
@@ -66,12 +66,64 @@ const cartSlice = createSlice({
           !(item.id === action.payload.id && item.size === action.payload.size)
       );
     },
+    incrementItemQuantity: (
+      state,
+      action: PayloadAction<{
+        id: GoodsOption['id'];
+        size: GoodsOption['size'];
+      }>
+    ) => {
+      const item = state.find(
+        item =>
+          item.id === action.payload.id && item.size === action.payload.size
+      );
+      if (item) {
+        item.quantity += 1;
+      }
+    },
+    decrementItemQuantity: (
+      state,
+      action: PayloadAction<{
+        id: GoodsOption['id'];
+        size: GoodsOption['size'];
+      }>
+    ) => {
+      const item = state.find(
+        item =>
+          item.id === action.payload.id && item.size === action.payload.size
+      );
+      if (item) {
+        item.quantity -= 1;
+      }
+    },
+    changeItemQuantity: (
+      state,
+      action: PayloadAction<{
+        id: GoodsOption['id'];
+        size: GoodsOption['size'];
+        quantity: GoodsOption['quantity'];
+      }>
+    ) => {
+      const item = state.find(
+        item =>
+          item.id === action.payload.id && item.size === action.payload.size
+      );
+      if (item) {
+        item.quantity = action.payload.quantity;
+      }
+    },
   },
 });
 
 export default cartSlice.reducer;
 
-export const { addCartItem, removeCartItem } = cartSlice.actions;
+export const {
+  addCartItem,
+  removeCartItem,
+  incrementItemQuantity,
+  decrementItemQuantity,
+  changeItemQuantity,
+} = cartSlice.actions;
 
 export const selectCart = (state: RootState) => state.cart;
 


### PR DESCRIPTION
## 구현 내용
![Animation](https://user-images.githubusercontent.com/37580351/180829566-144e7e54-529d-4c26-b673-1786dc9bfb3c.gif)

장바구니 아이템별로 각각의 수량을 조절하고 개별 삭제 기능을 추가 했습니다.