### PR TITLE
Feat: 장바구니 아이템 선택 삭제 모달 기능 구현

### DIFF
--- a/client/src/components/CartTool/DeleteAction.tsx
+++ b/client/src/components/CartTool/DeleteAction.tsx
@@ -1,24 +1,12 @@
 import * as React from 'react';
 import { useModalDispatch } from '@context/ModalContext';
-import { useAppDispatch, useAppSelector } from '@store/hooks';
-import {
-  removeSelectedCartItem,
-  selectCartItemCheckedCount,
-} from '@store/slices/cartSlice';
 import { styles } from './styles';
 
 export default function DeleteAction(): React.ReactElement {
-  const cartItemCheckedCount = useAppSelector(selectCartItemCheckedCount);
-
-  const appDispatch = useAppDispatch();
   const modalDispatch = useModalDispatch();
 
   const onClick = () => {
-    if (cartItemCheckedCount === 0) {
-      modalDispatch({ type: 'OPEN_MODAL' });
-      return;
-    }
-    appDispatch(removeSelectedCartItem());
+    modalDispatch({ type: 'OPEN_MODAL' });
   };
 
   return (

--- a/client/src/components/CartTool/RenderModalDialog.tsx
+++ b/client/src/components/CartTool/RenderModalDialog.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import AlertModal from '@components/AlertModal';
+import ConfirmModal from '@components/ConfirmModal';
+import { useModalDispatch } from '@context/ModalContext';
+import { useAppDispatch, useAppSelector } from '@store/hooks';
+import {
+  removeSelectedCartItem,
+  selectCartItemCheckedCount,
+} from '@store/slices/cartSlice';
+
+export default function RenderModalDialog() {
+  const cartItemCheckedCount = useAppSelector(selectCartItemCheckedCount);
+
+  const appDispatch = useAppDispatch();
+  const modalDispatch = useModalDispatch();
+
+  const onConfirm = () => {
+    modalDispatch({ type: 'CLOSE_MODAL' });
+    appDispatch(removeSelectedCartItem());
+  };
+
+  return (
+    <>
+      {cartItemCheckedCount === 0 && (
+        <AlertModal>
+          <p>선택한 상품이 없습니다.</p>
+          <p>삭제할 상품을 선택하세요</p>
+        </AlertModal>
+      )}
+      {cartItemCheckedCount > 0 && (
+        <ConfirmModal
+          message="선택한 상품을 삭제하시겠습니까?"
+          onConfirm={onConfirm}
+        />
+      )}
+    </>
+  );
+}

--- a/client/src/components/CartTool/index.tsx
+++ b/client/src/components/CartTool/index.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react';
-import AlertModal from '@components/AlertModal';
 import ModalProvider from '@context/ModalContext';
 import CartAllCheckbox from './CartAllCheckbox';
 import DeleteAction from './DeleteAction';
+import RenderModalDialog from './RenderModalDialog';
 import { styles } from './styles';
 
-export default function CartTool(): React.ReactElement {
+export default function CartTool() {
   return (
     <div css={styles.cartToolZone}>
       <CartAllCheckbox />
       <ModalProvider>
         <DeleteAction />
-        <AlertModal>
-          <p>선택한 상품이 없습니다.</p>
-          <p>삭제할 상품을 선택하세요</p>
-        </AlertModal>
+        <RenderModalDialog />
       </ModalProvider>
     </div>
   );

--- a/client/src/components/ConfirmModal/index.tsx
+++ b/client/src/components/ConfirmModal/index.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import ModalView from '@components/ModalView';
+import { useModalDispatch } from '@context/ModalContext';
+import { styles } from './styles';
+
+interface Props {
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+}
+
+export default function ConfirmModal({
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+}: Props) {
+  const modalDispatch = useModalDispatch();
+  const onCancel = () => {
+    modalDispatch({ type: 'CLOSE_MODAL' });
+  };
+
+  return (
+    <ModalView>
+      <div css={styles.modalBody}>
+        <p css={styles.modalMessage}>{message}</p>
+        <div css={styles.modalActions}>
+          <button onClick={onConfirm || onCancel}>
+            {confirmText || '확인'}
+          </button>
+          <button onClick={onCancel}>{cancelText || '취소'}</button>
+        </div>
+      </div>
+    </ModalView>
+  );
+}

--- a/client/src/components/ConfirmModal/styles.tsx
+++ b/client/src/components/ConfirmModal/styles.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  modalBody: css({
+    width: 230,
+    [mq('xs')]: {
+      width: 300,
+    },
+  }),
+  modalMessage: css({
+    textAlign: 'center',
+    padding: '40px 0',
+  }),
+  modalActions: css({
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    button: {
+      width: '40%',
+      padding: '10px 0',
+      borderRadius: 5,
+      backgroundColor: '#ddd',
+      fontWeight: 700,
+      transition: '0.5s',
+      '&:hover': {
+        backgroundColor: '#eee',
+      },
+      '&:first-of-type': {
+        color: '#ff0000',
+      },
+    },
+  }),
+};


### PR DESCRIPTION
## 구현 내용
![Animation](https://user-images.githubusercontent.com/37580351/181073747-f2a851ff-985d-4562-8e55-ff18f8dca159.gif)

장바구니에서 현재 선택된 아이템이 없다면, 알림 모달을 띄우고
선택한 아이템이 있는 경우, 확인/취소 버튼을 누를 수 있는 모달을 띄우도록 구현했습니다.

close #25 