### PR TITLE
Refactor: 모달 열고 닫을 때, 페이지 컨텐츠 움직임 개선

### DIFF
--- a/client/src/components/ModalView/index.tsx
+++ b/client/src/components/ModalView/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useModal, useModalDispatch } from '@context/ModalContext';
 import useDelayUnmount from '@hooks/useDelayUnmount';
 import useDetectElementOutside from '@hooks/useDetectElementOutside';
@@ -12,6 +12,9 @@ interface Props {
 export default function ModalView({ children }: Props) {
   const modal = useModal();
   const isMounted = useDelayUnmount(modal, 500);
+  const scrollBarWidthRef = useRef(
+    window.innerWidth - document.body.clientWidth
+  );
 
   const modalDispatch = useModalDispatch();
   const setModalRef = useDetectElementOutside<HTMLDivElement>(modal, () =>
@@ -21,9 +24,11 @@ export default function ModalView({ children }: Props) {
   useEffect(() => {
     if (isMounted) {
       document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${scrollBarWidthRef.current}px`;
     }
     return () => {
-      document.body.style.overflow = 'auto';
+      document.body.style.overflow = '';
+      document.body.style.paddingRight = '0px';
     };
   }, [isMounted]);
 


### PR DESCRIPTION
## 발생한 문제

모달 오픈시 스크롤 생성을 방지하는 코드 때문에, 기존 컨텐츠로 돌아올 때 스크롤이 재생성 되면서 컨텐츠의 움직임이 감지되는 문제가 있음.

![2_animation](https://user-images.githubusercontent.com/37580351/181577734-a2d43b4b-3059-40c1-ae06-b6dc2b69d429.gif)

## 개선 내용

padding 값을 스크롤 너비만큼 추가하여 모달 토글시, 컨텐츠의 움직임을 최소화하도록 함.

![1_animation](https://user-images.githubusercontent.com/37580351/181578187-e172b972-9a95-4128-a0b6-0d076102662a.gif)

