### PR TITLE
Add: 상품 찜하기 버튼, 클릭 이벤트 추가

### DIFF
--- a/client/src/components/GoodsItem/AddToWish.tsx
+++ b/client/src/components/GoodsItem/AddToWish.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { useAppDispatch, useAppSelector } from '@store/hooks';
+import {
+  addWishItem,
+  removeWishItem,
+  selectIsWishItem,
+} from '@store/slices/wishSlice';
+import { GoodsData } from '@typings/db';
+import { styles } from './styles';
+
+interface Props {
+  item: GoodsData;
+}
+
+export default function AddToWish({ item }: Props) {
+  const isWishItem = useAppSelector(state => selectIsWishItem(state, item.id));
+  const appDispatch = useAppDispatch();
+
+  const onClick = () => {
+    if (!isWishItem) {
+      appDispatch(addWishItem(item));
+    } else {
+      appDispatch(removeWishItem(item.id));
+    }
+  };
+
+  return (
+    <button onClick={onClick} css={styles.wishButton}>
+      찜하기
+    </button>
+  );
+}

--- a/client/src/components/GoodsItem/AddToWish.tsx
+++ b/client/src/components/GoodsItem/AddToWish.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { RiHeartAddLine } from 'react-icons/ri';
 import { useAppDispatch, useAppSelector } from '@store/hooks';
 import {
   addWishItem,
@@ -26,7 +27,8 @@ export default function AddToWish({ item }: Props) {
 
   return (
     <button onClick={onClick} css={styles.wishButton}>
-      찜하기
+      <span>찜하기</span>
+      <RiHeartAddLine size="2rem" color={isWishItem ? '#ff0000' : 'inherit'} />
     </button>
   );
 }

--- a/client/src/components/GoodsItem/GoodsOptionActions.tsx
+++ b/client/src/components/GoodsItem/GoodsOptionActions.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import CheckCartModal from '@components/CheckCartModal';
+import { ModalProvider } from '@context/ModalContext';
+import { GoodsData } from '@typings/db';
+import AddToCart from './AddToCart';
+import AddToWish from './AddToWish';
+import { styles } from './styles';
+
+interface Props {
+  item: GoodsData;
+  selectedRef: React.MutableRefObject<Set<string | number>>;
+}
+
+export default function GoodsOptionActions({ item, selectedRef }: Props) {
+  return (
+    <div css={styles.actionButtonWrapper}>
+      <AddToWish item={item} />
+      <ModalProvider>
+        <AddToCart />
+        <CheckCartModal selectedRef={selectedRef} />
+      </ModalProvider>
+    </div>
+  );
+}

--- a/client/src/components/GoodsItem/GoodsOptionPicker.tsx
+++ b/client/src/components/GoodsItem/GoodsOptionPicker.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { useRef } from 'react';
 import AlertModal from '@components/AlertModal';
-import CheckCartModal from '@components/CheckCartModal';
 import { ModalProvider } from '@context/ModalContext';
 import { useOption } from '@context/OptionContext';
 import { GoodsData } from '@typings/db';
-import AddToCart from './AddToCart';
+import GoodsOptionActions from './GoodsOptionActions';
 import GoodsOptionDropdown from './GoodsOptionDropdown';
 import SelectedOption from './SelectedOption';
 import { styles } from './styles';
@@ -33,10 +32,7 @@ export default function GoodsOptionPicker({ item }: Props) {
           />
         ))}
       </div>
-      <ModalProvider>
-        <AddToCart />
-        <CheckCartModal selectedRef={selectedRef} />
-      </ModalProvider>
+      <GoodsOptionActions item={item} selectedRef={selectedRef} />
     </div>
   );
 }

--- a/client/src/components/GoodsItem/styles.tsx
+++ b/client/src/components/GoodsItem/styles.tsx
@@ -148,8 +148,15 @@ export const styles = {
     border: '1px solid #ddd',
     fontSize: '1.6rem',
     transition: '0.5s',
+    span: {
+      verticalAlign: 'top',
+      marginRight: 10,
+    },
     '&:hover': {
       borderColor: '#333',
+      '& :not(span)': {
+        color: '#ff0000',
+      },
     },
   }),
 };

--- a/client/src/components/GoodsItem/styles.tsx
+++ b/client/src/components/GoodsItem/styles.tsx
@@ -125,8 +125,11 @@ export const styles = {
       },
     },
   }),
+  actionButtonWrapper: css({
+    display: 'flex',
+  }),
   cartButton: css({
-    width: '100%',
+    width: '50%',
     padding: 10,
     margin: '10px 0',
     backgroundColor: '#333',
@@ -136,6 +139,17 @@ export const styles = {
     '&:disabled': {
       cursor: 'auto',
       backgroundColor: '#ddd',
+    },
+  }),
+  wishButton: css({
+    width: '50%',
+    padding: 10,
+    margin: '10px 0',
+    border: '1px solid #ddd',
+    fontSize: '1.6rem',
+    transition: '0.5s',
+    '&:hover': {
+      borderColor: '#333',
     },
   }),
 };

--- a/client/src/layouts/App/AppLayout.tsx
+++ b/client/src/layouts/App/AppLayout.tsx
@@ -6,6 +6,7 @@ import { LoaderProvider } from '@context/LoaderContext';
 import Header from '@layouts/Header';
 import { useAppSelector } from '@store/hooks';
 import { selectCart } from '@store/slices/cartSlice';
+import { selectWishItems } from '@store/slices/wishSlice';
 import { mq } from '@styles/mediaQueries';
 
 const styles = {
@@ -20,10 +21,12 @@ const styles = {
 
 export default function AppLayout() {
   const cart = useAppSelector(selectCart);
+  const wishItems = useAppSelector(selectWishItems);
 
   useEffect(() => {
     localStorage.setItem('cart', JSON.stringify(cart));
-  }, [cart]);
+    localStorage.setItem('wishlist', JSON.stringify(wishItems));
+  }, [cart, wishItems]);
 
   return (
     <>

--- a/client/src/store/slices/wishSlice.ts
+++ b/client/src/store/slices/wishSlice.ts
@@ -1,0 +1,68 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { getLocalStorage } from '@lib/utils';
+import { RootState } from '@store/store';
+import { GoodsData } from '@typings/db';
+
+interface WishState {
+  items: GoodsData[];
+  wishId: number[];
+}
+
+const checkWishList = (value: any): value is GoodsData[] => {
+  if (Array.isArray(value)) {
+    const isWishList = value.every(value => {
+      if (
+        'id' in value &&
+        'name' in value &&
+        'price' in value &&
+        'img' in value &&
+        'size' in value &&
+        'category' in value
+      ) {
+        return true;
+      }
+      return false;
+    });
+
+    if (isWishList) return true;
+
+    return false;
+  }
+
+  return false;
+};
+
+const initialState: WishState = {
+  items: getLocalStorage('wishlist', checkWishList) || [],
+  wishId: [],
+};
+
+const wishSlice = createSlice({
+  name: 'wishSlice',
+  initialState,
+  reducers: {
+    addWishItem: (state, action: PayloadAction<GoodsData>) => {
+      state.items.push(action.payload);
+      state.wishId.push(action.payload.id);
+    },
+    removeWishItem: (state, action: PayloadAction<number>) => {
+      const filteredItems = state.items.filter(
+        item => item.id !== action.payload
+      );
+      const wishIndex = state.wishId.indexOf(action.payload);
+      if (wishIndex !== -1) {
+        state.wishId.splice(wishIndex, 1);
+      }
+
+      state.items = filteredItems;
+    },
+  },
+});
+
+export const wishReducer = wishSlice.reducer;
+
+export const { addWishItem, removeWishItem } = wishSlice.actions;
+
+export const selectIsWishItem = (state: RootState, id: number) =>
+  state.wish.wishId.includes(id);

--- a/client/src/store/slices/wishSlice.ts
+++ b/client/src/store/slices/wishSlice.ts
@@ -33,9 +33,13 @@ const checkWishList = (value: any): value is GoodsData[] => {
   return false;
 };
 
+const wishStorage = getLocalStorage('wishlist', checkWishList);
+
+const wishStorageId = wishStorage?.map(item => item.id);
+
 const initialState: WishState = {
-  items: getLocalStorage('wishlist', checkWishList) || [],
-  wishId: [],
+  items: wishStorage || [],
+  wishId: wishStorageId || [],
 };
 
 const wishSlice = createSlice({
@@ -66,3 +70,5 @@ export const { addWishItem, removeWishItem } = wishSlice.actions;
 
 export const selectIsWishItem = (state: RootState, id: number) =>
   state.wish.wishId.includes(id);
+
+export const selectWishItems = (state: RootState) => state.wish.items;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { cartReducer } from './slices/cartSlice';
+import { wishReducer } from './slices/wishSlice';
 
 export const store = configureStore({
   reducer: {
     cart: cartReducer,
+    wish: wishReducer,
   },
 });
 


### PR DESCRIPTION
## 구현 내용

![1_animation](https://user-images.githubusercontent.com/37580351/183957975-7f71b2c7-436d-440e-a75f-a6cfa5f76557.gif)

- 상품 상세 페이지에 해당 상품 찜하기 버튼 생성
- 버튼 클릭시, 이전 찜 상태에 따라 현재 찜 상태 변경하도록 이벤트 추가
- 새로고침 시에도 현재 찜 상태가 유지될 수 있도록 로컬 스토리지에 찜 상태 저장